### PR TITLE
Update TinkerForge README.md 

### DIFF
--- a/bundles/binding/org.openhab.binding.tinkerforge/README.md
+++ b/bundles/binding/org.openhab.binding.tinkerforge/README.md
@@ -168,6 +168,7 @@ A configuration line for a TinkerForge Device looks like this in services/tinker
 ```
 
 The *symbolic name* string can be used in the items configuration as an alternative for the uid and subid values.
+If you have more than one device of the same type you have to choose a unique *symbolic name* for every device.
 
 The following table lists the general available properties.
 


### PR DESCRIPTION
Added explanation for using symbolic names if more than one device of the same type is used.
Related coumminty forum thread:
https://community.openhab.org/t/how-to-use-multiple-tinkerforge-io-16-bricklet/36749

Signed-off-by: Siegfried Huismann <sihui@gmx.de>